### PR TITLE
Do not override the selected version

### DIFF
--- a/assets/plugin.js
+++ b/assets/plugin.js
@@ -1,9 +1,11 @@
 require(['gitbook', 'jQuery', 'lodash'], function (gitbook, $, _) {
-    var versions = [];
+    var versions = [],
+        current  = undefined;
 
     // Update the select with a list of versions
     function updateVersions(_versions) {
         versions = _versions || versions;
+        current  = $('.versions-select select').val();
 
         // Cleanup existing selector
         $('.versions-select').remove();
@@ -18,7 +20,7 @@ require(['gitbook', 'jQuery', 'lodash'], function (gitbook, $, _) {
 
         _.each(versions, function(version) {
             var $option = $('<option>', {
-                'selected': version.selected,
+                'selected': (current === undefined ? version.selected : (current === version.value)),
                 'value': version.value,
                 'text': version.text
             });


### PR DESCRIPTION
We're using several branches to manage different versions of our books. In each branch, the `selected` property in `book.json` is set up to match the current branch.

Unfortunately, the plugin loads the latest version from external URL, and then sets the selected version in the dropdown always to the latest version. Which obviously does not match with what you're currently reading.

This PR makes the dropdown not change the selected value but only updated the list of options from external URL.
