### PR TITLE
Fix - version selector reset after selecting a doc section.

### DIFF
--- a/assets/plugin.js
+++ b/assets/plugin.js
@@ -6,7 +6,7 @@ require(['gitbook', 'jQuery'], function (gitbook, $) {
     // Update the select with a list of versions
     function updateVersions(_versions) {
         versions = _versions || versions;
-        current  = $('.versions-select select').val();
+        current  = $('.versions-select select').val() || current;
 
         // Cleanup existing selector
         $('.versions-select').remove();


### PR DESCRIPTION
Now, the previous selected version is remembered.

When it happens:
- configuration with fixed options defined in shared config using gitbookConfigURL
  - each branch contains a single option with its URL nad version name, so that it is set as current before the shared gitbookConfigURL is loaded, so that it is selected as current after more options are loaded
- when a page is first loaded, updateVersions() is called twice - first with the option defined in the book.json in the git branch (this selects the correct current version), the second time it is called with all options defined in shared gitbookConfigURL config
- when a section of a documentation is selected, the section content is loaded, the selector widget disappears, and updateVersions() is called once
  - at this point, updateVersions() cannot read the value of current, as the widget does not exist and it always preselects the first option in gitbookConfigURL
  - this is not desired - the proposed fix remembers the current version if the widget with the current selection is not found
