### PR TITLE
Add `repository` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "index.js",
   "author": "Samy Pesse <samypesse@gmail.com>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GitbookIO/plugin-versions"
+  },
   "engines": {
     "gitbook": ">=2.6.2"
   },


### PR DESCRIPTION
Hi! This repo is currently not linked from [NPM](https://www.npmjs.com/package/gitbook-plugin-versions) or the [Gitbook Plugin page](https://plugins.gitbook.com/plugin/versions). This PR adds the `repository` field to `package.json` to fix that.